### PR TITLE
Fix tab color resetting

### DIFF
--- a/iterm-tab-color.plugin.zsh
+++ b/iterm-tab-color.plugin.zsh
@@ -22,6 +22,8 @@ function try_set_tab_color() {
       iterm_tab_color "$tcConfigColors[$k]"
       return 0
     fi
+
+    iterm_tab_color
   done
 }
 


### PR DESCRIPTION
Tab colors weren't being reset to the default after a command or
directory change.